### PR TITLE
Amend email regexp to make a last part of username optional

### DIFF
--- a/lib/normailize/email_address.rb
+++ b/lib/normailize/email_address.rb
@@ -25,7 +25,7 @@ module Normailize
     # local or domain part of your email addresses, make sure to strip them for
     # normalization purposes. For '@' in the local part to be allowed, split
     # local and domain part at the _last_ occurrence of the @-symbol.
-    EMAIL_ADDRESS_REGEX = /\A([a-z0-9_\-][a-z0-9_\-\+\.]{,62})?[a-z0-9_\-]@(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)+[a-z]{2,}\z/i
+    EMAIL_ADDRESS_REGEX = /\A([a-z0-9_\-][a-z0-9_\-\+\.]{,62})?[a-z0-9_\-]?@(([a-z0-9]|[a-z0-9][a-z0-9\-]*[a-z0-9])\.)+[a-z]{2,}\z/i
 
     # Public: Class initializer
     #

--- a/lib/normailize/version.rb
+++ b/lib/normailize/version.rb
@@ -1,3 +1,3 @@
 module Normailize
-  VERSION = "0.0.1"
+  VERSION = "0.0.2"
 end


### PR DESCRIPTION
This PR changes `EMAIL_ADDRESS_REGEX` so that emails like `nata.91.best+@gmail.com` would pass validation.